### PR TITLE
Update the the way backup file are named

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 dist
 node_modules
+
+# Webstorm
+.idea

--- a/src/backup.ts
+++ b/src/backup.ts
@@ -54,7 +54,8 @@ const dumpToFile = async (path: string) => {
 export const backup = async () => {
   console.log("Initiating DB backup...")
 
-  const timestamp = new Date().toISOString()
+  let date = new Date().toISOString()
+  const timestamp = date.replace(/[:.]+/g, '-')
   const filename = `backup-${timestamp}.tar.gz`
   const filepath = `/tmp/${filename}`
 


### PR DESCRIPTION
New file naming format is `backup-2022-09-28T14-00-00-059Z.tar.gz`

This should fix https://github.com/railwayapp-templates/postgres-s3-backups/issues/2