### PR TITLE
Allow customisation of backup format

### DIFF
--- a/src/backup.ts
+++ b/src/backup.ts
@@ -36,7 +36,7 @@ const dumpToFile = async (path: string) => {
 
   await new Promise((resolve, reject) => {
     exec(
-      `pg_dump ${env.BACKUP_DATABASE_URL} -F t | gzip > ${path}`,
+      `pg_dump -Fc ${env.BACKUP_DATABASE_URL} > ${path}`,
       (error, stdout, stderr) => {
         if (error) {
           reject({ error: JSON.stringify(error), stderr });
@@ -56,7 +56,7 @@ export const backup = async () => {
 
   let date = new Date().toISOString()
   const timestamp = date.replace(/[:.]+/g, '-')
-  const filename = `backup-${timestamp}.tar.gz`
+  const filename = `backup-${timestamp}.dump`
   const filepath = `/tmp/${filename}`
 
   await dumpToFile(filepath)

--- a/src/backup.ts
+++ b/src/backup.ts
@@ -56,7 +56,7 @@ export const backup = async () => {
 
   let date = new Date().toISOString()
   const timestamp = date.replace(/[:.]+/g, '-')
-  const filename = `backup-${timestamp}.dump`
+  const filename = `backup-${timestamp}.${env.BACKUP_FILE_FORMAT}`
   const filepath = `/tmp/${filename}`
 
   await dumpToFile(filepath)

--- a/src/env.ts
+++ b/src/env.ts
@@ -18,4 +18,9 @@ export const env = envsafe({
     default: '',
     allowEmpty: true,
   }),
+  BACKUP_FILE_FORMAT: str({
+    desc: 'The custom archive file format e.g dump, bak.',
+    default: 'dump',
+    allowEmpty: true,
+  })
 })


### PR DESCRIPTION
Backup format defaults to `.dump`:

Output a custom-format archive suitable for input into pg_restore. Together with the directory output format, this is the most flexible output format in that it allows manual selection and reordering of archived items during restoration. This format is also compressed by default.

[See PostgresSQL documentation](https://www.postgresql.org/docs/current/app-pgdump.html)