### PR TITLE
Allow backup folder specifications

### DIFF
--- a/src/backup.ts
+++ b/src/backup.ts
@@ -58,9 +58,12 @@ export const backup = async () => {
   const timestamp = date.replace(/[:.]+/g, '-')
   const filename = `backup-${timestamp}.${env.BACKUP_FILE_FORMAT}`
   const filepath = `/tmp/${filename}`
+  const aws_path = env.AWS_BACKUP_FOLDER
+            ? `${env.AWS_BACKUP_FOLDER}/${filename}`
+            : filename
 
   await dumpToFile(filepath)
-  await uploadToS3({name: filename, path: filepath})
+  await uploadToS3({name: aws_path, path: filepath})
 
   console.log("DB backup complete...")
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -22,5 +22,10 @@ export const env = envsafe({
     desc: 'The custom archive file format e.g dump, bak.',
     default: 'dump',
     allowEmpty: true,
+  }),
+  AWS_BACKUP_FOLDER: str({
+    desc: 'Specify back up folder. e.g My-App-01-DB-Backups',
+    default: '',
+    allowEmpty: true,
   })
 })


### PR DESCRIPTION
Sometimes you may have a single bucket that you are using to back up multiple databases that are related to the same application. This PR allows customisation to the backup folder through the `AWS_BACKUP_FOLDER` variable.
